### PR TITLE
bug(navbar): fix scroll issue on open mobile nav

### DIFF
--- a/src/pages/Navbar.tsx
+++ b/src/pages/Navbar.tsx
@@ -31,7 +31,7 @@ const Navbar = ({ translate, setTranslate }: Props) => {
       <div
         className={` ${
           navbarOpen ? "flex" : "hidden"
-        } bg-regal-blue flex-col absolute bottom-0 top-0 right-0 left-0 sm:hidden text-off-white h-screen flex justify-center duration-500
+        } bg-regal-blue flex-col fixed w-full bottom-0 top-0 right-0 left-0 sm:hidden text-off-white h-screen flex justify-center duration-500
         `}
       >
         <section className="h-4/5 py-10">


### PR DESCRIPTION
Adds a "fixed" style to the navbar when open. This way the scrolling is hidden from the page and the user can't scroll past the open navbar on mobile.

Closes: #30 